### PR TITLE
Change hash substring to be 26 characters instead of 20.

### DIFF
--- a/cleverbot.py
+++ b/cleverbot.py
@@ -39,7 +39,7 @@ class Session(object):
 
         def Send(self):
                 data=encode(self.keylist,self.arglist)
-                digest_txt=data[9:29].encode('utf-8')
+                digest_txt=data[9:35].encode('utf-8')
                 hash=hashlib.md5(digest_txt).hexdigest()
                 self.arglist[self.keylist.index('icognocheck')]=hash
                 data=encode(self.keylist,self.arglist)


### PR DESCRIPTION
Cleverbot released an update that requires the first 26 characters after `stimulus=` in the post body to be hashed for the `incognocheck` parameter. Previously it only required the first 20. Since the update, if you only hash 20 characters, you end up getting 'DENIED' back for the session ID.
